### PR TITLE
feat(#39): add controller stub functionality for controllers

### DIFF
--- a/src/controllers/groups.js
+++ b/src/controllers/groups.js
@@ -1,24 +1,58 @@
+const Group = require('../models/Group');
+
 const GroupController = {
-  index: (req, res, next) => {
-    return res.send('GET /groups [index]');
+  index: async (req, res, next) => {
+    const groups = Object
+      .values(req.userOrganizations)
+      .map(org => org.groups)
+      .flat();
+
+    return res.render('groups/index', {
+      groups,
+    });
   },
-  show: (req, res, next) => {
-    return res.send(`GET /groups/${req.params.groupId} [show]`);
+  show: async (req, res, next) => {
+    const group = await Group.findById(req.params.groupId).populate('messages');
+
+    return res.render('groups/show', {
+      group,
+    });
   },
-  create: (req, res, next) => {
-    return res.send('POST /groups [create]');
+  create: async (req, res, next) => {
+    const group = await Group.create({
+      ...req.body,
+      admins: [req.user],
+      organization: { _id: req.body.organizationId },
+    });
+    req.flash('success', `${group.toString()} group has been successfully created.`);
+
+    return res.redirect('/groups');
   },
-  new: (req, res, next) => {
-    return res.send('GET /groups/new [new]');
+  new: async (req, res, next) => {
+    const group = new Group();
+
+    return res.render('groups/form', {
+      group,
+    });
   },
-  update: (req, res, next) => {
-    return res.send(`POST /groups/${req.params.groupId} [update]`);
+  update: async (req, res, next) => {
+    const group = await Group.findById(req.params.groupId).update(req.body);
+    req.flash('success', `${group.toString()} group has been successfully updated.`);
+
+    return res.redirect('/groups');
   },
-  edit: (req, res, next) => {
-    return res.send(`GET /groups/${req.params.groupId}/edit [edit]`);
+  edit: async (req, res, next) => {
+    const group = Group.findById(req.params.groupId);
+
+    return res.render('groups/form', {
+      group,
+    });
   },
-  destroy: (req, res, next) => {
-    return res.send(`DELETE /groups/${req.params.groupId} [destroy]`);
+  destroy: async (req, res, next) => {
+    const group = await Group.findOneAndDelete(req.params.groupId);
+    req.flash('success', `${group.toString()} group has been successfully deleted.`);
+
+    return res.redirect('/groups');
   },
 };
 

--- a/src/controllers/messages.js
+++ b/src/controllers/messages.js
@@ -1,26 +1,44 @@
+const Group = require('../models/Group');
+const Message = require('../models/Message');
+
 const MessagesController = {
-  // index: (req, res, next) => {
+  // index: async (req, res, next) => {
   //   return res.send(`GET /groups/${req.params.groupId}/messages [index]`);
   // },
-  show: (req, res, next) => {
-    return res.send(`GET /groups/${req.params.groupId}/messages/${req.params.messageId} [show]`);
-  },
-  create: (req, res, next) => {
-    return res.send(`POST /groups/${req.params.groupId}/messages [create]`);
-  },
-  new: (req, res, next) => {
-    res.render('common/groupMessageCreation', {
-      csrfToken: req.csrfToken(),
-      currentUser: req.user,
+  show: async (req, res, next) => {
+    const message = await Message.findById(req.params.messageId);
+
+    return render('messages/show', {
+      message,
     });
   },
-  // update: (req, res, next) => {
+  create: async (req, res, next) => {
+    const group = await Group.findById(req.params.groupId);
+    const message = await Message.create({
+      ...req.body,
+      group,
+      poster: req.user,
+    });
+    // TODO: send the message out to everyone in the group
+    req.flash('success', `Your message has been posted.`);
+
+    return res.redirect('/messages');
+  },
+  new: async (req, res, next) => {
+    const message = new Message();
+
+    return res.render('common/groupMessageCreation', {
+      message,
+      csrfToken: req.csrfToken(),
+    });
+  },
+  // update: async (req, res, next) => {
   //   return res.send(`POST /groups/${req.params.groupId}/messages/${req.params.messageId} [update]`);
   // },
-  // edit: (req, res, next) => {
+  // edit: async (req, res, next) => {
   //   return res.send(`GET /groups/${req.params.groupId}/messages/${req.params.messageId}/edit [edit]`);
   // },
-  // destroy: (req, res, next) => {
+  // destroy: async (req, res, next) => {
   //   return res.send(`DELETE /groups/${req.params.groupId}/messages/${req.params.messageId} [destroy]`);
   // },
 };

--- a/src/controllers/preferences.js
+++ b/src/controllers/preferences.js
@@ -1,24 +1,58 @@
+const Group = require('../models/Group');
+const Preference = require('../models/Preference');
+
 const PreferencesController = {
-  // index: (req, res, next) => {
+  // index: async (req, res, next) => {
   //   return res.send(`GET /groups/${req.params.groupId}/preferences [index]`);
   // },
-  // show: (req, res, next) => {
+  // show: async (req, res, next) => {
   //   return res.send(`GET /groups/${req.params.groupId}/preferences/${req.params.preferenceId} [show]`);
   // },
-  // create: (req, res, next) => {
+  // create: async (req, res, next) => {
   //   return res.send(`POST /groups/${req.params.groupId}/preferences [create]`);
   // },
-  // new: (req, res, next) => {
+  // new: async (req, res, next) => {
   //   return res.send(`GET /groups/${req.params.groupId}/new [new]`);
   // },
-  update: (req, res, next) => {
-    return res.send(`POST /groups/${req.params.groupId}/preferences [update]`);
+  update: async (req, res, next) => {
+    // We do a sort of upsert here.
+    const group = await Group.findById(req.params.groupId);
+    let preference = await Preference.findOne({
+      group,
+      user: req.user,
+    });
+    if (!preference) {
+      // TODO: refactor this into som sort of upsert logic
+      preference = await Preference.create({
+        group,
+        user: req.user,
+      });
+    }
+    // TODO: update emails and phoneNumbers; not sure what body is yet
+    await preference.save();
+    req.flash('success', 'You Preferences for this group have been successfully updated.');
+
+    return res.redirect('/');
   },
-  edit: (req, res, next) => {
-    return res.send(`GET /groups/${req.params.groupId}/preferences [edit]`);
+  edit: async (req, res, next) => {
+    let preference = await Preference.findOne({
+      group,
+      user: req.user,
+    });
+    if (!preference) {
+      // TODO: refactor this into som sort of upsert logic
+      preference = await Preference.create({
+        group,
+        user: req.user,
+      });
+    }
+
+    return res.render('preferences/form', {
+      preference,
+    });
   },
   // },
-  // destroy: (req, res, next) => {
+  // destroy: async (req, res, next) => {
   //   return res.send(`DELETE /groups/${req.params.groupId}/preferences/${req.params.preferenceId} [destroy]`);
   // },
 };

--- a/src/models/Preference.js
+++ b/src/models/Preference.js
@@ -20,8 +20,14 @@ const PreferenceSchema = new mongoose.Schema({
     ref: 'Group',
     required: true
   },
-  emails: [EmailSchema],
-  phoneNumbers: [PhoneSchema],
+  emails: {
+    type: [EmailSchema],
+    default: [],
+  },
+  phoneNumbers: {
+    type: [PhoneSchema],
+    default: [],
+  },
 },{
   timestamps: true,
   toJSON: { virtuals: true },


### PR DESCRIPTION
This PR adds stub functionality for all of the controller route handlers. Currently most of them will throw errors since they're trying to serve up templates that do not exist yet. This will be fixed as part of subsequent PRs for other issues; this is just a runway PR.